### PR TITLE
feat: add mobile-friendly AI chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# API-WEB
+# AI-WEB
+
+A simple mobile-friendly web client for interacting with AI APIs. It supports custom API URL and API key and displays conversations in a ChatGPT-like interface.
+
+## Usage
+
+Open `index.html` in a browser. Use the settings button to configure your API URL and key, then start chatting.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Chat Client</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <h1 class="title">AI Chat Client</h1>
+      <button id="settingsBtn" class="settings-btn" aria-label="Settings">
+        ⚙️
+      </button>
+    </header>
+    <main id="chat" class="chat-area"></main>
+    <form id="inputForm" class="input-bar">
+      <textarea
+        id="messageInput"
+        placeholder="Type your message..."
+        rows="1"
+      ></textarea>
+      <button type="submit">Send</button>
+    </form>
+
+    <div id="settingsModal" class="modal hidden">
+      <div class="modal-content">
+        <h2>Settings</h2>
+        <label
+          >API URL
+          <input
+            id="apiUrl"
+            type="text"
+            placeholder="https://api.openai.com/v1/chat/completions"
+          />
+        </label>
+        <label
+          >API Key
+          <input id="apiKey" type="text" />
+        </label>
+        <button id="saveSettings">Save</button>
+      </div>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,79 @@
+const chatEl = document.getElementById("chat");
+const inputForm = document.getElementById("inputForm");
+const messageInput = document.getElementById("messageInput");
+const settingsBtn = document.getElementById("settingsBtn");
+const settingsModal = document.getElementById("settingsModal");
+const apiUrlInput = document.getElementById("apiUrl");
+const apiKeyInput = document.getElementById("apiKey");
+const saveSettingsBtn = document.getElementById("saveSettings");
+
+let messages = [];
+
+function appendMessage(role, content) {
+  const messageEl = document.createElement("div");
+  messageEl.className = `message ${role}`;
+  const bubble = document.createElement("div");
+  bubble.className = "bubble";
+  bubble.textContent = content;
+  messageEl.appendChild(bubble);
+  chatEl.appendChild(messageEl);
+  chatEl.scrollTop = chatEl.scrollHeight;
+}
+
+function loadSettings() {
+  apiUrlInput.value =
+    localStorage.getItem("apiUrl") ||
+    "https://api.openai.com/v1/chat/completions";
+  apiKeyInput.value = localStorage.getItem("apiKey") || "";
+}
+
+function saveSettings() {
+  localStorage.setItem("apiUrl", apiUrlInput.value);
+  localStorage.setItem("apiKey", apiKeyInput.value);
+  settingsModal.classList.add("hidden");
+}
+
+settingsBtn.addEventListener("click", () => {
+  loadSettings();
+  settingsModal.classList.remove("hidden");
+});
+
+saveSettingsBtn.addEventListener("click", saveSettings);
+
+settingsModal.addEventListener("click", (e) => {
+  if (e.target === settingsModal) settingsModal.classList.add("hidden");
+});
+
+inputForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const content = messageInput.value.trim();
+  if (!content) return;
+  appendMessage("user", content);
+  messages.push({ role: "user", content });
+  messageInput.value = "";
+
+  const apiUrl = localStorage.getItem("apiUrl");
+  const apiKey = localStorage.getItem("apiKey");
+
+  try {
+    const res = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages,
+      }),
+    });
+    const data = await res.json();
+    const reply = data.choices?.[0]?.message?.content?.trim() || "No response";
+    appendMessage("ai", reply);
+    messages.push({ role: "assistant", content: reply });
+  } catch (err) {
+    appendMessage("ai", "Error: " + err.message);
+  }
+});
+
+loadSettings();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,102 @@
+body {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f7f7f8;
+}
+/*. Top bar */
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: #343541;
+  color: #fff;
+}
+.settings-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+/*. Chat area */
+.chat-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+.message {
+  margin-bottom: 1rem;
+}
+.message .bubble {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  max-width: 80%;
+  word-wrap: break-word;
+}
+.message.user {
+  text-align: right;
+}
+.message.user .bubble {
+  background: #d1e7dd;
+}
+.message.ai {
+  text-align: left;
+}
+.message.ai .bubble {
+  background: #fff;
+}
+/*. Input bar */
+.input-bar {
+  display: flex;
+  padding: 0.5rem;
+  background: #fff;
+}
+.input-bar textarea {
+  flex: 1;
+  resize: none;
+  border: none;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+.input-bar button {
+  margin-left: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+/*. Modal */
+.modal.hidden {
+  display: none;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+}
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+}
+.modal-content label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+.modal-content input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- add responsive ChatGPT-style UI for chatting with AI APIs
- allow customizing API URL and key via settings modal
- document usage of the web client

## Testing
- `npx --yes prettier --check index.html style.css script.js README.md`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689e0536ea5c832eb95ed9fa7a459fe7