### PR TITLE
feat: add mobile-friendly AI chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# API-WEB
+# AI-WEB
+
+A simple mobile-friendly web client for interacting with AI APIs. It supports custom API provider, model selection, API URL and key, and displays conversations in a ChatGPT-like interface. The interface text is in Chinese.
+
+## Usage
+
+Open `index.html` in a browser. Use the settings button to choose an API provider, configure your API URL and key, then start chatting. Select the model from the drop-down in the top bar.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI聊天客户端</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <h1 class="title">AI聊天客户端</h1>
+      <select id="modelSelect" class="model-select"></select>
+      <input
+        id="customModel"
+        class="model-input hidden"
+        type="text"
+        placeholder="模型名称"
+      />
+      <button id="settingsBtn" class="settings-btn" aria-label="设置">
+        ⚙️
+      </button>
+    </header>
+    <main id="chat" class="chat-area"></main>
+    <form id="inputForm" class="input-bar">
+      <textarea id="messageInput" placeholder="输入消息..." rows="1"></textarea>
+      <button type="submit">发送</button>
+    </form>
+
+    <div id="settingsModal" class="modal hidden">
+      <div class="modal-content">
+        <h2>设置</h2>
+        <label
+          >API提供商
+          <select id="provider">
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="custom">自定义</option>
+          </select>
+        </label>
+        <label
+          >接口地址
+          <input
+            id="apiUrl"
+            type="text"
+            placeholder="https://api.openai.com/v1/chat/completions"
+          />
+        </label>
+        <label
+          >API密钥
+          <input id="apiKey" type="text" />
+        </label>
+        <button id="saveSettings">保存</button>
+      </div>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,162 @@
+const chatEl = document.getElementById("chat");
+const inputForm = document.getElementById("inputForm");
+const messageInput = document.getElementById("messageInput");
+const settingsBtn = document.getElementById("settingsBtn");
+const settingsModal = document.getElementById("settingsModal");
+const apiUrlInput = document.getElementById("apiUrl");
+const apiKeyInput = document.getElementById("apiKey");
+const saveSettingsBtn = document.getElementById("saveSettings");
+const providerSelect = document.getElementById("provider");
+const modelSelect = document.getElementById("modelSelect");
+const customModelInput = document.getElementById("customModel");
+
+const providers = {
+  openai: {
+    url: "https://api.openai.com/v1/chat/completions",
+    models: ["gpt-3.5-turbo", "gpt-4o"],
+  },
+  anthropic: {
+    url: "https://api.anthropic.com/v1/messages",
+    models: ["claude-3-haiku", "claude-3-sonnet"],
+  },
+  custom: {
+    url: "",
+    models: [],
+  },
+};
+
+let messages = [];
+
+function appendMessage(role, content) {
+  const messageEl = document.createElement("div");
+  messageEl.className = `message ${role}`;
+  const bubble = document.createElement("div");
+  bubble.className = "bubble";
+  bubble.textContent = content;
+  messageEl.appendChild(bubble);
+  chatEl.appendChild(messageEl);
+  chatEl.scrollTop = chatEl.scrollHeight;
+}
+
+function populateModels(provider) {
+  modelSelect.innerHTML = "";
+  const models = providers[provider].models;
+  models.forEach((m) => {
+    const opt = document.createElement("option");
+    opt.value = m;
+    opt.textContent = m;
+    modelSelect.appendChild(opt);
+  });
+  const customOpt = document.createElement("option");
+  customOpt.value = "custom";
+  customOpt.textContent = "自定义模型";
+  modelSelect.appendChild(customOpt);
+}
+
+function toggleCustomModelInput() {
+  if (modelSelect.value === "custom") {
+    customModelInput.classList.remove("hidden");
+  } else {
+    customModelInput.classList.add("hidden");
+  }
+}
+
+function loadSettings() {
+  const provider = localStorage.getItem("provider") || "openai";
+  providerSelect.value = provider;
+  populateModels(provider);
+  apiUrlInput.value = localStorage.getItem("apiUrl") || providers[provider].url;
+  apiKeyInput.value = localStorage.getItem("apiKey") || "";
+  const model =
+    localStorage.getItem("model") || providers[provider].models[0] || "";
+  if (providers[provider].models.includes(model)) {
+    modelSelect.value = model;
+  } else {
+    modelSelect.value = "custom";
+    customModelInput.value = model;
+  }
+  toggleCustomModelInput();
+}
+
+function saveSettings() {
+  localStorage.setItem("provider", providerSelect.value);
+  localStorage.setItem("apiUrl", apiUrlInput.value);
+  localStorage.setItem("apiKey", apiKeyInput.value);
+  localStorage.setItem("model", getSelectedModel());
+  settingsModal.classList.add("hidden");
+}
+
+settingsBtn.addEventListener("click", () => {
+  loadSettings();
+  settingsModal.classList.remove("hidden");
+});
+
+saveSettingsBtn.addEventListener("click", saveSettings);
+
+providerSelect.addEventListener("change", () => {
+  const provider = providerSelect.value;
+  apiUrlInput.placeholder = providers[provider].url;
+  if (provider !== "custom") {
+    apiUrlInput.value = providers[provider].url;
+  }
+  populateModels(provider);
+  modelSelect.value = providers[provider].models[0] || "custom";
+  if (modelSelect.value === "custom") {
+    customModelInput.value = localStorage.getItem("model") || "";
+  }
+  toggleCustomModelInput();
+});
+
+function getSelectedModel() {
+  return modelSelect.value === "custom"
+    ? customModelInput.value.trim()
+    : modelSelect.value;
+}
+
+modelSelect.addEventListener("change", () => {
+  toggleCustomModelInput();
+  localStorage.setItem("model", getSelectedModel());
+});
+
+customModelInput.addEventListener("change", () => {
+  localStorage.setItem("model", getSelectedModel());
+});
+
+settingsModal.addEventListener("click", (e) => {
+  if (e.target === settingsModal) settingsModal.classList.add("hidden");
+});
+
+inputForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const content = messageInput.value.trim();
+  if (!content) return;
+  appendMessage("user", content);
+  messages.push({ role: "user", content });
+  messageInput.value = "";
+
+  const apiUrl = localStorage.getItem("apiUrl");
+  const apiKey = localStorage.getItem("apiKey");
+  const model = localStorage.getItem("model") || getSelectedModel();
+
+  try {
+    const res = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+      }),
+    });
+    const data = await res.json();
+    const reply = data.choices?.[0]?.message?.content?.trim() || "无响应";
+    appendMessage("ai", reply);
+    messages.push({ role: "assistant", content: reply });
+  } catch (err) {
+    appendMessage("ai", "错误: " + err.message);
+  }
+});
+
+loadSettings();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,117 @@
+body {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f7f7f8;
+}
+.hidden {
+  display: none;
+}
+/*. Top bar */
+.top-bar {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: #343541;
+  color: #fff;
+  gap: 0.5rem;
+}
+.top-bar .title {
+  flex: 1;
+}
+.model-select,
+.model-input {
+  padding: 0.25rem;
+  border-radius: 4px;
+  border: none;
+}
+.model-input {
+  max-width: 8rem;
+}
+.settings-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+/*. Chat area */
+.chat-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+.message {
+  margin-bottom: 1rem;
+}
+.message .bubble {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  max-width: 80%;
+  word-wrap: break-word;
+}
+.message.user {
+  text-align: right;
+}
+.message.user .bubble {
+  background: #d1e7dd;
+}
+.message.ai {
+  text-align: left;
+}
+.message.ai .bubble {
+  background: #fff;
+}
+/*. Input bar */
+.input-bar {
+  display: flex;
+  padding: 0.5rem;
+  background: #fff;
+}
+.input-bar textarea {
+  flex: 1;
+  resize: none;
+  border: none;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+.input-bar button {
+  margin-left: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+/*. Modal */
+.modal.hidden {
+  display: none;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+}
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+}
+.modal-content label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+.modal-content input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- add responsive ChatGPT-style UI for chatting with AI APIs
- allow customizing API URL, provider, and model with Chinese interface
- document usage of the web client

## Testing
- `npx --yes prettier --check index.html style.css script.js README.md`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689e0536ea5c832eb95ed9fa7a459fe7